### PR TITLE
Make pytest-runner a conditional requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,16 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 from setuptools import setup
 
 README = open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
 CONTRIB = open(os.path.join(os.path.dirname(__file__), "CONTRIBUTING.rst")).read()
 CHANGES = open(os.path.join(os.path.dirname(__file__), "CHANGES.rst")).read()
 version = open(os.path.join(os.path.dirname(__file__), "VERSION.txt")).read().strip()
+
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name="luma.oled",
@@ -28,7 +32,7 @@ setup(
     packages=["luma.oled"],
     zip_safe=False,
     install_requires=["luma.core>=0.2.0"],
-    setup_requires=["pytest-runner"],
+    setup_requires=[] + pytest_runner,
     tests_require=["mock", "pytest", "pytest-cov", "python-coveralls"],
     classifiers=[
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hi, I am trying to embed luma into my project which uses Buildroot Embedded Linux. Pytest is not provided at the time of installation and so it fails.

I feel like this is a good compromise and it is also what [other packages seem to be doing](https://github.com/thombashi/DataProperty/issues/19).