### PR TITLE
Fix setup.py to not fail if default encoding is not set to UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,13 @@
 
 import os
 import sys
+from io import open
+
 from setuptools import setup
 
 
-def read_file(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as r:
+def read_file(fname, encoding='utf-8'):
+    with open(os.path.join(os.path.dirname(__file__), fname), encoding=encoding) as r:
         return r.read()
 
 


### PR DESCRIPTION
`pip install .` in a git checkout failed on my C.H.I.P. with:

    $ pip install .
    Processing /home/chip/luma.oled
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-fb3wdsty-build/setup.py", line 15, in <module>
            CONTRIB = read_file("CONTRIBUTING.rst")
          File "/tmp/pip-fb3wdsty-build/setup.py", line 11, in read_file
            return r.read()
          File "/home/chip/.virtualenvs/xair-remote/lib/python3.4/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 679: ordinal not in range(128)
        
        ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-fb3wdsty-build/

This is probably because the `sitecustomize.py` file on this system doesn't set the default encoding in `sys` to `utf-8`, which may be the case on other systems too. So the encoding must be explicitly specified when reading a non-ascii file in text mode.