### PR TITLE
added support for 96 x 96 ssd1351 mikroe board

### DIFF
--- a/luma/oled/device.py
+++ b/luma/oled/device.py
@@ -334,11 +334,11 @@ class ssd1351(device):
         self.framebuffer = getattr(luma.core.framebuffer, framebuffer)(self)
 
         settings = {
-            (128,128):  dict(width=0x7F, height=0x7F, displayoffset=0x00, startline=0x00, remap=0x00),
-            (96,96):    dict(width=0x6F, height=0x5F, displayoffset=0x00, startline=0x00, remap=0x02)
+            (128, 128):  dict(width=0x7F, height=0x7F, displayoffset=0x00, startline=0x00, remap=0x00),
+            (96, 96):    dict(width=0x6F, height=0x5F, displayoffset=0x00, startline=0x00, remap=0x02)
         }.get((width, height))
 
-        if settings == None:
+        if settings is None:
             raise luma.core.error.DeviceDisplayModeError(
                 "Unsupported display mode: {0} x {1}".format(width, height))
 
@@ -379,8 +379,8 @@ class ssd1351(device):
 
         if self.framebuffer.redraw_required(image):
             left, top, right, bottom = self.framebuffer.bounding_box
-            _,_,w,h = self.bounding_box
-            if w == 95 and h == 95 :
+            _, _, w, h = self.bounding_box
+            if w == 95 and h == 95:
                 left += 16
                 right += 16
             width = right - left

--- a/luma/oled/device.py
+++ b/luma/oled/device.py
@@ -356,27 +356,42 @@ class ssd1351(device):
             raise luma.core.error.DeviceDisplayModeError(
                 "Unsupported display mode: {0} x {1}".format(width, height))
 
-        self.command(0xFD, 0x12)                                                    # Unlock IC MCU interface
+        # Unlock IC MCU interface
+        self.command(0xFD, 0x12)
         # Command A2,B1,B3,BB,BE,C1 accessible if in unlock state
         self.command(0xFD, 0xB1)
-        self.command(0xAE)                                                          # Display off
-        self.command(0xB3, 0xF1)                                                    # Clock divider
-        self.command(0xCA, 0x7F)                                                    # Mux ratio
-        self.command(0x15, settings['displayoffset'], settings['width'])            # Set column address
-        self.command(0x75, settings['displayoffset'], settings['height'])           # Set row address
-        # Segment remapping # Column address remapping or else everthing is mirrored
+        # Display off
+        self.command(0xAE)
+        # Clock divider
+        self.command(0xB3, 0xF1)
+        # Mux ratio
+        self.command(0xCA, 0x7F)
+        # Set column address
+        self.command(0x15, settings['displayoffset'], settings['width'])
+        # Set row address
+        self.command(0x75, settings['displayoffset'], settings['height'])
+        # Segment remapping - Column address remapping or else everything is mirrored
         self.command(0xA0, 0x74 | settings['remap'])
-        self.command(0xA1, settings['startline'])                                   # Set Display start line
-        self.command(0xA2, 0x00)                                                    # Set display offset
-        self.command(0xB5, 0x00)                                                    # Set GPIO
+        # Set Display start line
+        self.command(0xA1, settings['startline'])
+        # Set display offset
+        self.command(0xA2, 0x00)
+        # Set GPIO
+        self.command(0xB5, 0x00)                                                    
         # Function select (internal - diode drop)
         self.command(0xAB, 0x01)
-        self.command(0xB1, 0x32)                                                    # Precharge
-        self.command(0xB4, 0xA0, 0xB5, 0x55)                                        # Set segment low voltage
-        self.command(0xBE, 0x05)                                                    # Set VcomH voltage
-        self.command(0xC7, 0x0F)                                                    # Contrast master
-        self.command(0xB6, 0x01)                                                    # Precharge2
-        self.command(0xA6)                                                          # Normal display
+        # Precharge
+        self.command(0xB1, 0x32)
+        # Set segment low voltage
+        self.command(0xB4, 0xA0, 0xB5, 0x55)
+        # Set VcomH voltage
+        self.command(0xBE, 0x05)
+        # Contrast master
+        self.command(0xC7, 0x0F)
+        # Precharge2
+        self.command(0xB6, 0x01)
+        # Normal display
+        self.command(0xA6)
 
         self.contrast(0xFF)
         self.clear()

--- a/luma/oled/device.py
+++ b/luma/oled/device.py
@@ -351,26 +351,26 @@ class ssd1351(device):
             self.apply_offsets = offset
         else:
             self.apply_offsets = lambda bbox: bbox
-            
+
         if settings is None:
             raise luma.core.error.DeviceDisplayModeError(
                 "Unsupported display mode: {0} x {1}".format(width, height))
 
         self.command(0xFD, 0x12)                                                    # Unlock IC MCU interface
         # Command A2,B1,B3,BB,BE,C1 accessible if in unlock state
-        self.command(0xFD, 0xB1)                                                    
+        self.command(0xFD, 0xB1)
         self.command(0xAE)                                                          # Display off
         self.command(0xB3, 0xF1)                                                    # Clock divider
         self.command(0xCA, 0x7F)                                                    # Mux ratio
         self.command(0x15, settings['displayoffset'], settings['width'])            # Set column address
         self.command(0x75, settings['displayoffset'], settings['height'])           # Set row address
         # Segment remapping # Column address remapping or else everthing is mirrored
-        self.command(0xA0, 0x74 | settings['remap'])                                
+        self.command(0xA0, 0x74 | settings['remap'])
         self.command(0xA1, settings['startline'])                                   # Set Display start line
         self.command(0xA2, 0x00)                                                    # Set display offset
         self.command(0xB5, 0x00)                                                    # Set GPIO
         # Function select (internal - diode drop)
-        self.command(0xAB, 0x01)                                                    
+        self.command(0xAB, 0x01)
         self.command(0xB1, 0x32)                                                    # Precharge
         self.command(0xB4, 0xA0, 0xB5, 0x55)                                        # Set segment low voltage
         self.command(0xBE, 0x05)                                                    # Set VcomH voltage

--- a/luma/oled/device.py
+++ b/luma/oled/device.py
@@ -334,32 +334,32 @@ class ssd1351(device):
         self.framebuffer = getattr(luma.core.framebuffer, framebuffer)(self)
 
         settings = {
-            (128,128): dict(width=0x7f, height=0x7f, displayoffset=0x00, startline=0x00, remap=0x00),
-            (96,96): dict(width=0x6f, height=0x5f, displayoffset=0x00, startline=0x00, remap=0x02)
+            (128,128):  dict(width=0x7F, height=0x7F, displayoffset=0x00, startline=0x00, remap=0x00),
+            (96,96):    dict(width=0x6F, height=0x5F, displayoffset=0x00, startline=0x00, remap=0x02)
         }.get((width, height))
 
         if settings == None:
             raise luma.core.error.DeviceDisplayModeError(
                 "Unsupported display mode: {0} x {1}".format(width, height))
 
-        self.command(0xFD, 0x12)              # Unlock IC MCU interface
-        self.command(0xFD, 0xB1)              # Command A2,B1,B3,BB,BE,C1 accessible if in unlock state
-        self.command(0xAE)                    # Display off
-        self.command(0xB3, 0xF1)              # Clock divider
-        self.command(0xCA, 0x7f)              # Mux ratio
-        self.command(0x15, settings['displayoffset'], settings['width'])        # Set column address
-        self.command(0x75, settings['displayoffset'], settings['height'])        # Set row address
-        self.command(0xA0, 0x74 | settings['remap'])              # Segment remapping # Column address remapping or else everthing is mirrored
-        self.command(0xA1, settings['startline'])              # Set Display start line
-        self.command(0xA2, 0x00)              # Set display offset
-        self.command(0xB5, 0x00)              # Set GPIO
-        self.command(0xAB, 0x01)              # Function select (internal - diode drop)
-        self.command(0xB1, 0x32)              # Precharge
-        self.command(0xB4, 0xA0, 0xB5, 0x55)  # Set segment low voltage
-        self.command(0xBE, 0x05)              # Set VcomH voltage
-        self.command(0xC7, 0x0F)              # Contrast master
-        self.command(0xB6, 0x01)              # Precharge2
-        self.command(0xA6)                    # Normal display
+        self.command(0xFD, 0x12)                                                    # Unlock IC MCU interface
+        self.command(0xFD, 0xB1)                                                    # Command A2,B1,B3,BB,BE,C1 accessible if in unlock state
+        self.command(0xAE)                                                          # Display off
+        self.command(0xB3, 0xF1)                                                    # Clock divider
+        self.command(0xCA, 0x7F)                                                    # Mux ratio
+        self.command(0x15, settings['displayoffset'], settings['width'])            # Set column address
+        self.command(0x75, settings['displayoffset'], settings['height'])           # Set row address
+        self.command(0xA0, 0x74 | settings['remap'])                                # Segment remapping # Column address remapping or else everthing is mirrored
+        self.command(0xA1, settings['startline'])                                   # Set Display start line
+        self.command(0xA2, 0x00)                                                    # Set display offset
+        self.command(0xB5, 0x00)                                                    # Set GPIO
+        self.command(0xAB, 0x01)                                                    # Function select (internal - diode drop)
+        self.command(0xB1, 0x32)                                                    # Precharge
+        self.command(0xB4, 0xA0, 0xB5, 0x55)                                        # Set segment low voltage
+        self.command(0xBE, 0x05)                                                    # Set VcomH voltage
+        self.command(0xC7, 0x0F)                                                    # Contrast master
+        self.command(0xB6, 0x01)                                                    # Precharge2
+        self.command(0xA6)                                                          # Normal display
 
         self.contrast(0xFF)
         self.clear()

--- a/luma/oled/device.py
+++ b/luma/oled/device.py
@@ -377,7 +377,7 @@ class ssd1351(device):
         # Set display offset
         self.command(0xA2, 0x00)
         # Set GPIO
-        self.command(0xB5, 0x00)                                                    
+        self.command(0xB5, 0x00)
         # Function select (internal - diode drop)
         self.command(0xAB, 0x01)
         # Precharge


### PR DESCRIPTION
added support for 96 x 96 ssd1351 mikroe board
framebuffer was mirrored and viewport was misaligned. 
all examples work on the mikroe OLED C click using this driver.