### PR TITLE
Rework SSD1351 initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     namespace_packages=["luma"],
     packages=["luma.oled"],
     zip_safe=False,
-    install_requires=["luma.core>=1.1.1"],
+    install_requires=["luma.core>=1.6.0"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={

--- a/tests/test_ssd1351.py
+++ b/tests/test_ssd1351.py
@@ -57,6 +57,53 @@ def test_init_128x128():
     ]
 
 
+def test_init_96x96_with_BGR():
+    """
+    SSD1351 OLED with a 96 x 96 resolution and BGR pixels works correctly.
+    """
+    recordings = []
+
+    def data(data):
+        recordings.append({'data': data})
+
+    def command(*cmd):
+        recordings.append({'command': list(cmd)})
+
+    serial.command.side_effect = command
+    serial.data.side_effect = data
+
+    ssd1351(serial, width=96, height=96, bgr=True)
+
+    assert serial.data.called
+    assert serial.command.called
+
+    assert recordings == [
+        {'command': [253]}, {'data': [18]},
+        {'command': [253]}, {'data': [177]},
+        {'command': [174]},
+        {'command': [179]}, {'data': [241]},
+        {'command': [202]}, {'data': [127]},
+        {'command': [21]}, {'data': [0, 95]},
+        {'command': [117]}, {'data': [0, 95]},
+        {'command': [160]}, {'data': [118]},
+        {'command': [161]}, {'data': [0]},
+        {'command': [162]}, {'data': [0]},
+        {'command': [181]}, {'data': [0]},
+        {'command': [171]}, {'data': [1]},
+        {'command': [177]}, {'data': [50]},
+        {'command': [180]}, {'data': [160, 181, 85]},
+        {'command': [190]}, {'data': [5]},
+        {'command': [199]}, {'data': [15]},
+        {'command': [182]}, {'data': [1]},
+        {'command': [166]},
+        {'command': [193]}, {'data': [255, 255, 255]},
+        {'command': [21]}, {'data': [0, 95]},
+        {'command': [117]}, {'data': [0, 95]},
+        {'command': [92]}, {'data': [0] * (96 * 96 * 2)},
+        {'command': [175]}
+    ]
+
+
 def test_init_invalid_dimensions():
     """
     SSD1351 OLED with an invalid resolution raises a


### PR DESCRIPTION
* Set width/height accordingly
* Use `bgr=True` flag to indicate BGR rather than RGB color ordering
* Revert formatting changes
* Add init sequence test for 96x96 SSD1351 with BGR pixels

See recent comments in #192 