### PR TITLE
Fix regression bug caused by device consolidation PR

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ ChangeLog
 +------------+---------------------------------------------------------------------+------------+
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
+| *upcoming* | * Fix bug where SSD1325/1327 didn't handle ``framebuffer`` properly |            |
++------------+---------------------------------------------------------------------+------------+
 | **3.0.0**  | * **BREAKING** Fix SSD1351 init sequence didn't set RGB/BGR color   | 2018/12/02 |
 |            |   order properly. Users of this device should verify proper color   |            |
 |            |   rendering and add ``bgr=True`` if blue/red color components       |            |

--- a/luma/oled/device/__init__.py
+++ b/luma/oled/device/__init__.py
@@ -462,11 +462,11 @@ class ssd1325(greyscale_device):
     display to properly configure it. Further control commands can then be
     called to affect the brightness and other settings.
     """
-    def __init__(self, serial_interface=None, width=128, height=64, rotate=0, mode="RGB", **kwargs):
+    def __init__(self, serial_interface=None, width=128, height=64, rotate=0,
+                 mode="RGB", framebuffer="full_frame", **kwargs):
         super(ssd1325, self).__init__(luma.core.const.common, serial_interface,
-                                      width, height, rotate, mode,
-                                      framebuffer="full_frame", nibble_order=1,
-                                      **kwargs)
+                                      width, height, rotate, mode, framebuffer,
+                                      nibble_order=1, **kwargs)
 
     def _supported_dimensions(self):
         return [(128, 64)]
@@ -509,11 +509,11 @@ class ssd1327(greyscale_device):
 
     .. versionadded:: 2.4.0
     """
-    def __init__(self, serial_interface=None, width=128, height=128, rotate=0, mode="RGB", **kwargs):
+    def __init__(self, serial_interface=None, width=128, height=128, rotate=0,
+                 mode="RGB", framebuffer="full_frame",  **kwargs):
         super(ssd1327, self).__init__(luma.core.const.common, serial_interface,
-                                      width, height, rotate, mode,
-                                      framebuffer="full_frame", nibble_order=1,
-                                      **kwargs)
+                                      width, height, rotate, mode, framebuffer,
+                                      nibble_order=1, **kwargs)
 
     def _supported_dimensions(self):
         return [(128, 128)]

--- a/tests/test_ssd1325.py
+++ b/tests/test_ssd1325.py
@@ -91,3 +91,10 @@ def test_monochrome_display():
 
     # Next 4096 bytes are data representing the drawn image
     serial.data.assert_called_once_with(get_json_data('demo_ssd1325_monochrome'))
+
+
+def test_framebuffer_override():
+    """
+    Reproduce https://github.com/rm-hull/luma.examples/issues/95
+    """
+    ssd1325(serial, mode="1", framebuffer="diff_to_previous")

--- a/tests/test_ssd1327.py
+++ b/tests/test_ssd1327.py
@@ -91,3 +91,9 @@ def test_monochrome_display():
 
     # Next 4096 bytes are data representing the drawn image
     serial.data.assert_called_once_with(get_json_data('demo_ssd1327_monochrome'))
+
+def test_framebuffer_override():
+    """
+    Reproduce https://github.com/rm-hull/luma.examples/issues/95
+    """
+    ssd1327(serial, mode="1", framebuffer="diff_to_previous")

--- a/tests/test_ssd1327.py
+++ b/tests/test_ssd1327.py
@@ -92,6 +92,7 @@ def test_monochrome_display():
     # Next 4096 bytes are data representing the drawn image
     serial.data.assert_called_once_with(get_json_data('demo_ssd1327_monochrome'))
 
+
 def test_framebuffer_override():
     """
     Reproduce https://github.com/rm-hull/luma.examples/issues/95


### PR DESCRIPTION
Fixes: https://github.com/rm-hull/luma.examples/issues/95

Note: affects SSD1325 and SSD1327 drivers.
Without the fix, the tests fail exactly the same way as reported in the above issue:

```
============================================= FAILURES =============================================
____________________________________ test_framebuffer_override _____________________________________

    def test_framebuffer_override():
        """
        Reproduce https://github.com/rm-hull/luma.examples/issues/95
        """
>       ssd1325(serial, mode="1", framebuffer="diff_to_previous")

tests/test_ssd1325.py:100: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <luma.oled.device.ssd1325 object at 0x10ec8b890>, serial_interface = <Mock id='4539280912'>
width = 128, height = 64, rotate = 0, mode = '1', kwargs = {'framebuffer': 'diff_to_previous'}

    def __init__(self, serial_interface=None, width=128, height=64, rotate=0, mode="RGB", **kwargs):
        super(ssd1325, self).__init__(luma.core.const.common, serial_interface,
                                      width, height, rotate, mode,
                                      framebuffer="full_frame", nibble_order=1,
>                                     **kwargs)
E       TypeError: __init__() got multiple values for keyword argument 'framebuffer'

luma/oled/device/__init__.py:469: TypeError
____________________________________ test_framebuffer_override _____________________________________

    def test_framebuffer_override():
        """
        Reproduce https://github.com/rm-hull/luma.examples/issues/95
        """
>       ssd1327(serial, mode="1", framebuffer="diff_to_previous")

tests/test_ssd1327.py:99: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <luma.oled.device.ssd1327 object at 0x10ec90ed0>, serial_interface = <Mock id='4539280912'>
width = 128, height = 128, rotate = 0, mode = '1', kwargs = {'framebuffer': 'diff_to_previous'}

    def __init__(self, serial_interface=None, width=128, height=128, rotate=0, mode="RGB", **kwargs):
        super(ssd1327, self).__init__(luma.core.const.common, serial_interface,
                                      width, height, rotate, mode,
                                      framebuffer="full_frame", nibble_order=1,
>                                     **kwargs)
E       TypeError: __init__() got multiple values for keyword argument 'framebuffer'

luma/oled/device/__init__.py:516: TypeError
=============================== 2 failed, 58 passed in 1.31 seconds ================================
ERROR: InvocationError: '/Users/rhu/dev/luma.oled/.tox/py27/bin/coverage run -m py.test -v -r wsx'
_____________________________________________ summary ______________________________________________
ERROR:   py27: commands failed
```