### PR TITLE
Adding support for 256x64 ssd1362 ELW2106AA (#268)

### DIFF
--- a/luma/oled/const.py
+++ b/luma/oled/const.py
@@ -33,3 +33,8 @@ class ssd1322(common):
     DISPLAYON = 0xAF
     DISPLAYOFF = 0xAE
     SETCONTRAST = 0xC1
+
+class ssd1362(common):
+    DISPLAYON = 0xAF
+    DISPLAYOFF = 0xAE
+    SETCONTRAST = 0xC1


### PR DESCRIPTION
Hi there,

thanks a lot for your great project and support. I have been adding a basic support for the ssd1362 oled screen (Futaba ELW2106AA) but the result is not great yet.

- Hardware : 
The screen is connected to a Rpi3 with 3-wire SPI connexion (MOSI, CLK, DC, RST, CS), it is powered with 16V for the OLED power supply and 3V3 for the VCI (Logic Supply).
- Software : 
The screen reacts to "luma.example" but only displaying a white line moving slowly from top to bottom.

```
~/dev/luma.examples $ python3 examples/demo.py --conf conf/ssd1362.conf 
Version: luma.oled 3.3.0 (luma.core 1.12.0)
Display: ssd1362
Interface: spi
Dimensions: 256 x 64
------------------------------------------------------------
Testing basic canvas graphics...
Testing contrast (dim/bright cycles)...   <-- screen starts to react
Testing display ON/OFF...
Testing clear display...
Testing screen updates...
```
Below is a small video of the current rendering (I have tried with two different new screens and same results).

![ELW2106AA_SSD1362_DEMO](https://user-images.githubusercontent.com/209875/71567690-470b2e00-2b04-11ea-94e2-3cf17657d033.gif)

May you guys have an idea of this issue ? Do I need some settings ? Does is seem to similar to previous issues ? 
Any hardware/software ideas is testable to possibly quickly add a full support to luma.oled

