### PR TITLE
tests: add timeout using pytest-timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 test_deps = [
     'pytest<=4.5',
-    'pytest-cov'
+    'pytest-cov',
+    'pytest-timeout'
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters = True
 commands =
     coverage erase
     python setup.py install
-    coverage run -m py.test -v -r wsx
+    coverage run -m py.test --timeout=10 -v -r wsx
     coverage report
     coverage html
 deps = .[test]


### PR DESCRIPTION
This doesn't fix the failing tests but those are related to Pillow 8.0, as seen in other luma projects. This just 'unfreezes' the test suite so it will always finish and not hang for hours on a particular test.