### PR TITLE
Pin setup to only use luma.core v1.x.y lineage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ ChangeLog
 +============+=====================================================================+============+
 | *TBA*      | * Drop support for Python 3.5, only 3.6 or newer is supported now   |            |
 |            | * Add support for SSD1351 128x96 display                            |            |
+|            | * Pin luma.core to 1.x.y line only, in anticipation of performance  |            |
+|            |   improvements in upcoming major release                            |            |
 +------------+---------------------------------------------------------------------+------------+
 | **3.6.0**  | * Add support for Winstar OLED displays                             | 2020/09/24 |
 +------------+---------------------------------------------------------------------+------------+

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     packages=find_packages(),
     namespace_packages=["luma"],
     zip_safe=False,
-    install_requires=["luma.core>=1.16.2"],
+    install_requires=["luma.core>=1.16.2,<2.0.0"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={


### PR DESCRIPTION
I want to introduce a breaking change in luma.core to improve performance. This will mean changing how the fullframe and diff-to-previous framebuffers work. I intend releasing that breaking feature as a 2.x.y release.

In order to be able to roll that out without breaking this project, we need to set the install_required to not upgrade luma.core to the 2.x.y release.

Shortly after luma.core 2.x.y is released, this package will be upgraded to use the improved framebuffer.