### PR TITLE
Update index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,8 +7,6 @@ Luma.OLED: Display drivers for SSD1306 / SSD1309 / SSD1322 / SSD1325 / SSD1327 /
 .. image:: https://coveralls.io/repos/github/rm-hull/luma.oled/badge.svg?branch=master
    :target: https://coveralls.io/github/rm-hull/luma.oled?branch=master
 
-.. image:: https://img.shields.io/maintenance/yes/2022.svg?maxAge=2592000
-
 .. image:: https://img.shields.io/pypi/pyversions/luma.oled.svg
     :target: https://pypi.python.org/pypi/luma.oled
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ Luma.OLED: Display drivers for SSD1306 / SSD1309 / SSD1322 / SSD1325 / SSD1327 /
 .. image:: https://coveralls.io/repos/github/rm-hull/luma.oled/badge.svg?branch=master
    :target: https://coveralls.io/github/rm-hull/luma.oled?branch=master
 
-.. image:: https://img.shields.io/maintenance/yes/2021.svg?maxAge=2592000
+.. image:: https://img.shields.io/maintenance/yes/2022.svg?maxAge=2592000
 
 .. image:: https://img.shields.io/pypi/pyversions/luma.oled.svg
     :target: https://pypi.python.org/pypi/luma.oled


### PR DESCRIPTION
Update maintenance badge for documentation as now the [main page](https://luma-oled.readthedocs.io/en/latest/) shows no maintenance since 2021. :sweat_smile: 