### PR TITLE
ci: correct branch name

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish Package
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-publish:

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,6 @@ luma.oled
 .. image:: https://img.shields.io/pypi/dm/luma.oled
    :target: https://pypi.python.org/project/luma.oled
 
-.. image:: https://img.shields.io/maintenance/yes/2022.svg?maxAge=2592000
-
 Python 3 library interfacing OLED matrix displays with the SSD1306, SSD1309,
 SSD1322, SSD1325, SSD1327, SSD1331, SSD1351, SH1106 or WS0010 driver using
 I2C/SPI/Parallel on the Raspberry Pi and other linux-based single-board


### PR DESCRIPTION
I also tagged 3.10.0 just now but it's not published to pypi, possibly because of the incorrect branch name?