### PR TITLE
ci: use gh-action-pypi-publish@release/v1

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,14 +23,14 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/ .
       - name: Publish package to test PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish package to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
See https://github.com/marketplace/actions/pypi-publish#-master-branch-sunset-

> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.